### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 setting.py
+kladsjfklasdjfklsjdfkjalfdkslajkf


### PR DESCRIPTION
Agregamos al gitignore para node.js

server

por ejemploo los archivos y la carpeta node.modulles ya no se subrn al repo, ver el archivo .gitignore completo